### PR TITLE
feat/refactor: add functionality to preserve original file names

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,7 @@ Schema::create('nova_pending_field_attachments', function (Blueprint $table) {
     $table->increments('id');
     $table->string('draft_id')->index();
     $table->string('attachment');
+    $table->string('original_name');
     $table->string('disk');
     $table->timestamps();
 });

--- a/README.md
+++ b/README.md
@@ -64,6 +64,14 @@ Schema::create('nova_field_attachments', function (Blueprint $table) {
 });
 ```
 
+**Note**: latest nova already includes these migrations. If so, you might receive error `Table already exists` while running migrations. In this case, you might only need to add `original_name` field in `nova_pending_field_attachments`:
+
+```php
+Schema::table('nova_pending_field_attachments', function (Blueprint $table) {
+    $table->string('original_name')->after('attachment');
+});
+```
+
 2. In your `app/Console/Kernel.php` file, you should register a daily job to prune any stale attachments from the pending attachments table and storage. Laravel Nova provides the job implementation needed to accomplish this:
 
 ```php

--- a/src/ImageGalleryField.php
+++ b/src/ImageGalleryField.php
@@ -109,7 +109,11 @@ class ImageGalleryField extends Trix
 
                 $stream = Storage::disk($this->disk)->readStream($this->storagePath.$pendingAttachment->attachment);
 
-                $media = $model->addMediaFromStream($stream)->toMediaCollection($attribute);
+                $media = $model
+                    ->addMediaFromStream($stream)
+                    ->usingFileName($pendingAttachment->original_name)
+                    ->toMediaCollection($attribute);
+
 
                 $imageOrder[$imageOrderIndex] = $media->id;
             });

--- a/src/StorePendingImage.php
+++ b/src/StorePendingImage.php
@@ -9,6 +9,7 @@ use Illuminate\Foundation\Validation\ValidatesRequests;
 use Illuminate\Http\Request;
 use Illuminate\Http\UploadedFile;
 use Illuminate\Support\Facades\Storage;
+use Illuminate\Support\Str;
 use Laravel\Nova\Fields\Attachments\PendingAttachment;
 
 class StorePendingImage
@@ -42,8 +43,10 @@ class StorePendingImage
 
         /** @var UploadedFile $file */
         $file = $request->file('attachment');
+        /** @var string $originalFileName */
+        $filePathinfo = pathinfo($file->getClientOriginalName());
         /** @var string $storageDir */
-        $storageDir = $this->field->getStorageDir();
+        $storageDir = rtrim($this->field->getStorageDir(), '/') . '/pending-images';
         /** @var string $disk */
         $disk = $this->field->getStorageDisk();
         /** @var string $draftId */
@@ -52,9 +55,10 @@ class StorePendingImage
         $attachment = $file->store($storageDir, $disk);
 
         $attachment = PendingAttachment::create([
-            'draft_id'   => $draftId,
-            'attachment' => $attachment,
-            'disk'       => $disk,
+            'draft_id'      => $draftId,
+            'attachment'    => $attachment,
+            'disk'          => $disk,
+            'original_name' => Str::slug($filePathinfo['filename']) . "." . strtolower($filePathinfo['extension'])
         ]);
 
         /** @var FilesystemAdapter $storage */

--- a/tests/FieldServiceProviderTest.php
+++ b/tests/FieldServiceProviderTest.php
@@ -22,6 +22,6 @@ it('adds the scripts when nova is serving', function () {
 
     Event::dispatch(new ServingNova(request()));
 
-    expect(Nova::$scripts)->toHaveLength(1);
-    expect(Nova::$scripts[0]->name())->toBe('image-gallery-field');
+    expect(Nova::$scripts)->toHaveLength(1)
+        ->and(Nova::$scripts[0]->name())->toBe('image-gallery-field');
 });

--- a/tests/ImageGalleryFieldTest.php
+++ b/tests/ImageGalleryFieldTest.php
@@ -204,7 +204,7 @@ it('deletes the given images to delete', function () {
         ->and($model->getMedia('images')->first()->id)->toEqual($imagesId->get(1));
 });
 
-it('images are created and stored with correct names', function () {
+it('creates and stores images with correct name and path', function () {
     Storage::fake();
 
     $field = new ImageGalleryField('images');

--- a/tests/ImageGalleryFieldTest.php
+++ b/tests/ImageGalleryFieldTest.php
@@ -22,19 +22,15 @@ function createNovaRequest(array $files = [], array $parameters = [])
 it('creates an instance', function () {
     $field = new ImageGalleryField('content');
 
-    expect($field->component)->toBe('image-gallery-field');
-
-    expect($field->jsonSerialize())->toMatchArray([
-        'uniqueKey' => 'content-default-image-gallery-field',
-        'attribute' => 'content',
-        'component' => 'image-gallery-field',
-    ]);
-
-    expect($field->disk)->toBe('public');
-
-    expect($field->storagePath)->toBe('/');
-
-    expect($field->withFiles)->toBe(true);
+    expect($field->component)->toBe('image-gallery-field')
+        ->and($field->jsonSerialize())->toMatchArray([
+            'uniqueKey' => 'content-default-image-gallery-field',
+            'attribute' => 'content',
+            'component' => 'image-gallery-field',
+        ])
+        ->and($field->disk)->toBe('public')
+        ->and($field->storagePath)->toBe('/')
+        ->and($field->withFiles)->toBe(true);
 });
 
 it('accepts custom single image rules', function () {
@@ -111,12 +107,13 @@ it('stores the new images in the given order', function () {
     $newImages = collect(range(1, 3))->map(function ($i) {
         return UploadedFile::fake()->image("image{$i}.png");
     })->map(function (UploadedFile $image) {
-        return $image->store('/', ['disk' => 'public']);
-    })->map(function (string $imageName) {
+        return ['hash_name' => $image->store('/', ['disk' => 'public']), 'original_name' => $image->name];
+    })->map(function (array $imageArray) {
         return PendingAttachment::create([
-            'draft_id'   => 'abc',
-            'attachment' => $imageName,
-            'disk'       => 'public',
+            'draft_id'      => 'abc',
+            'attachment'    => $imageArray['hash_name'],
+            'original_name' => $imageArray['original_name'],
+            'disk'          => 'public',
         ]);
     });
 
@@ -137,8 +134,8 @@ it('stores the new images in the given order', function () {
 
     $model->save();
 
-    expect($model->media('images')->get())->toHaveCount(3);
-    expect($model->getMedia('images')->pluck('id')->toArray())->toEqual($imageOrderIds);
+    expect($model->media('images')->get())->toHaveCount(3)
+        ->and($model->getMedia('images')->pluck('id')->toArray())->toEqual($imageOrderIds);
 });
 
 it('stores the previously added images in the given order', function () {
@@ -170,8 +167,8 @@ it('stores the previously added images in the given order', function () {
 
     $model->save();
 
-    expect($model->media('images')->get())->toHaveCount(3);
-    expect($model->getMedia('images')->pluck('id')->toArray())->toEqual($imageOrderIds);
+    expect($model->media('images')->get())->toHaveCount(3)
+        ->and($model->getMedia('images')->pluck('id')->toArray())->toEqual($imageOrderIds);
 });
 
 it('deletes the given images to delete', function () {
@@ -203,6 +200,59 @@ it('deletes the given images to delete', function () {
 
     $model->save();
 
-    expect($model->media('images')->get())->toHaveCount(1);
-    expect($model->getMedia('images')->first()->id)->toEqual($imagesId->get(1));
+    expect($model->media('images')->get())->toHaveCount(1)
+        ->and($model->getMedia('images')->first()->id)->toEqual($imagesId->get(1));
+});
+
+it('images are created and stored with correct names', function () {
+    Storage::fake();
+
+    $field = new ImageGalleryField('images');
+
+    $model = ExampleModel::create();
+
+    $newImages = collect(range(1, 3))->map(function ($i) {
+        return UploadedFile::fake()->image("sample-image-name-{$i}.png");
+    })->map(function (UploadedFile $image) {
+        return ['hash_name' => $image->store('/', ['disk' => 'public']), 'original_name' => $image->name];
+    })->map(function (array $imageArray) {
+        return PendingAttachment::create([
+            'draft_id'      => 'abc',
+            'attachment'    => $imageArray['hash_name'],
+            'original_name' => $imageArray['original_name'],
+            'disk'          => 'public',
+        ]);
+    });
+
+    // Ids of the pending attachments that need to be persisted
+    $newImagesIds = $newImages->pluck('id')->map(fn ($id) => (string) $id);
+
+    // The order for the new images contain a `new:` prefix
+    $imageOrderIds        = [$newImagesIds->get(1), $newImagesIds->get(0), $newImagesIds->get(2)];
+    $imageOrderWithPrefix = collect($imageOrderIds)->map(fn ($id) => "new:{$id}")->toArray();
+
+    $request = createNovaRequest(parameters: [
+        'images'        => $newImagesIds->toArray(),
+        'images_delete' => [],
+        'images_order'  => $imageOrderWithPrefix,
+    ]);
+
+    $field->fillInto(request: $request, model: $model, attribute: 'images');
+
+    $model->save();
+
+    $imagesFromMedia = $model->media('images')->get();
+
+    // Asserting the files are stored correctly
+    $imagesFromMedia->each(function ($image) {
+        $filePath = $image['id'].'/'.$image['file_name'];
+        // Assert the file was stored
+        Storage::disk('public')->assertExists($filePath);
+
+        // Assert the file name
+        $imageFilePath = Storage::disk('public')->path($filePath);
+        $fileName      = pathinfo($imageFilePath, PATHINFO_BASENAME);
+
+        expect($fileName)->toBe($image['file_name']);
+    });
 });

--- a/tests/StorePendingImageTest.php
+++ b/tests/StorePendingImageTest.php
@@ -67,11 +67,13 @@ it('stores the attachment and returns a json with the url and model id', functio
 
     $attachment = PendingAttachment::first();
 
-    expect($attachment->draft_id)->toBe('123');
-    expect($attachment->disk)->toBe('public');
-    expect($attachment->attachment)->toEndWith('.png');
+    expect($attachment->draft_id)->toBe('123')
+        ->and($attachment->disk)->toBe('public')
+        ->and($attachment->attachment)->toEndWith('.png')
+        ->and($attachment->original_name)->toBe($image->name)
+        ->and($response)->toBeJson()
+        ->and($response)->toContain(sprintf('{"url":"\/storage\/%s","id":%s}', str_replace('/', '\/', $attachment->attachment), $attachment->id));
 
-    expect($response)->toBeJson();
-
-    expect($response)->toContain(sprintf('{"url":"\/storage\/%s","id":%s}', $attachment->attachment, $attachment->id));
 });
+
+

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -44,6 +44,7 @@ abstract class TestCase extends Orchestra
             $table->increments('id');
             $table->string('draft_id')->index();
             $table->string('attachment');
+            $table->string('original_name');
             $table->string('disk');
             $table->timestamps();
         });


### PR DESCRIPTION

## Summary

For image SEO optimisation and generally handling file structure, I have made few changes:

- Pending files will be placed in separate folder, instead of directly putting it on disk
- Updated migration of pending files. It will include original file name as well
- Media library will take original name to save final image that will be used in slider

- #43 
