### PR TITLE
[NOVA5] Update constructor to allow nullable resolveCallback

### DIFF
--- a/src/ImageGalleryField.php
+++ b/src/ImageGalleryField.php
@@ -43,7 +43,7 @@ class ImageGalleryField extends Trix
      * @param  (callable(mixed, mixed, ?string):mixed)|null  $resolveCallback
      * @return void
      */
-    public function __construct($name, $attribute = null, callable $resolveCallback = null)
+    public function __construct($name, $attribute = null, ?callable $resolveCallback = null)
     {
         parent::__construct($name, $attribute, $resolveCallback);
 


### PR DESCRIPTION
## Summary

Fixes the following error:

PHP Deprecated:  Ardenthq\ImageGalleryField\ImageGalleryField::__construct(): Implicitly marking parameter $resolveCallback as nullable is deprecated, the explicit nullable type must be used instead in /var/www/html/vendor/ardenthq/nova-image-gallery-field/src/ImageGalleryField.php on line 46

This fix is combined with #65 , but for this nova5 branch.

<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure you're familiar with and follow the instructions in the [contributing guidelines](https://ark.dev/docs/program-incentives/guidelines/contributing).

Please fill out the information below to expedite the review and (hopefully) merge of your pull request!
-->



<!-- What changes are being made? -->

<!-- Why are these changes necessary? -->

<!-- How were these changes implemented? -->

## Checklist

<!-- Have you done all of these things (where applicable)?  -->

-   [x] I checked my (code) changes for obvious issues, debug statements and commented code
-   [ ] Documentation _(if necessary)_
-   [ ] Tests _(if necessary)_
-   [x] Ready to be merged

<!-- Feel free to add additional comments. -->
